### PR TITLE
Not listen all messages when the bot is in private groups

### DIFF
--- a/lib/tipbot.js
+++ b/lib/tipbot.js
@@ -315,10 +315,10 @@ TipBot.prototype.onMessage = function(channel, member, message) {
     }
 
     // debug message
-    debug(channel.name, member.name, message, channel.is_channel);
+    debug(channel.name, member.name, message, channel.is_channel, channel.is_group);
 
     // check if we should parse this
-    if (channel.is_channel && !message.match(self.slack.self.id)) {
+    if ((channel.is_channel || channel.is_group) && !message.match(self.slack.self.id)) {
         debug('MESSAGE NOT FOR ME!');
         return;
     }


### PR DESCRIPTION
While testing the bot in slack I found an unexpected behavior. When it is a private group and not a public channel the bot is listening to all messages instead of responding only to the ones in which is he mentioned.

The changes are minimal but it can be nasty having the bot in a private group and he responding all messages.

More info about private groups: https://api.slack.com/types/group
