### PR TITLE
[BUG] Convert command is not returning the expected value

### DIFF
--- a/lib/tipbot.js
+++ b/lib/tipbot.js
@@ -618,8 +618,6 @@ TipBot.prototype.onMessage = function(channel, member, message) {
                             channel.send(user.handle + ": we don't support that currency yet!");
                         } else if (!value) {
                             channel.send(user.handle + ": that's an invalid amount");
-                        } else if (originalCurrency) {
-                            channel.send(valueText);
                         } else {
                             self.getPriceRates(function(err, rates) {
                                 var rate = _.find(rates, {code: currency});


### PR DESCRIPTION
Using the "convert" command now have a bug. The value returned is not the expected.

When I say to the bot:

```

convert 100 EUR to USD
```

it answers:

```
100.00 EUR (0.39714264 BTC at 251.80 EUR / BTC)
```

I was expecting something as the quantity (100) in USD and -maybe- some optional info in Bitcoins.
I solved it to the bot returning the expected message and now when I execute:

```
convert 100 EUR to USD
```

it returns:

```
110.35 USD (277.86 USD / BTC)
```

I do not see any reason to use the elseif which I deleted
