### PR TITLE
Update regular expression for amount matching

### DIFF
--- a/lib/tipbot.js
+++ b/lib/tipbot.js
@@ -57,7 +57,7 @@ var TipBot = function(slack, BLOCKTRAIL_APIKEY, BLOCKTRAIL_APISECRET, SECRET, TE
     // will be updated with all available currencies when API call is done
     self.CURRENCIES = ['USD', 'EUR', 'GBP'];
     self.CURRENCY_REGEX = new RegExp('(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "ig");
-    self.AMOUNT_REGEX = new RegExp('(\\d+\\.?\\d*) *(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "i");
+    self.AMOUNT_REGEX = new RegExp('(\\d*(\\.\\d{1,8})?) *(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "i");
 
     self.getPriceRates(function(err, rates) {
         self.CURRENCIES = [];
@@ -69,7 +69,7 @@ var TipBot = function(slack, BLOCKTRAIL_APIKEY, BLOCKTRAIL_APISECRET, SECRET, TE
         });
 
         self.CURRENCY_REGEX = new RegExp('(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "ig");
-        self.AMOUNT_REGEX = new RegExp('(\\d+\\.?\\d*) *(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "i");
+        self.AMOUNT_REGEX = new RegExp('(\\d*(\\.\\d{1,8})?) *(Satoshis?|' + self.TICKER + '|' + self.CURRENCIES.join("|") + ')', "i");
     });
 
     self.users = {};


### PR DESCRIPTION
Fixes https://github.com/blocktrail/slack-tipbot/issues/14 by modifying the regular expression for amounts

Strings which are now accepted/handled include:
`.50555`, `11.`